### PR TITLE
chore: bump node-based actions to node24 where available

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -363,14 +363,14 @@ runs:
       fi
   - name: Upload dump artifact
     if: ${{ always() && inputs.enclave_dump == 'true' }}
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: "enclave-dump-${{ steps.kurtosis.outputs.enclave_name }}"
       path: "${{ steps.kurtosis.outputs.tempdir }}/dump"
 
   # remove kurtosis enclave
   - name: Remove kurtosis enclave
-    uses: gacts/run-and-post-run@d803f6920adc9a47eeac4cb6c93dbc2e2890c684 # v1.4.2
+    uses: gacts/run-and-post-run@598d7a875d5620e0457490555b5e18e46082aa47 # v1.4.4
     if: ${{ always() }}
     with:
       post: |


### PR DESCRIPTION
## Summary

Bumps the 2 transitive node20 actions that now have node24-compatible releases:

| Action | From | To | Runtime |
|---|---|---|---|
| `actions/upload-artifact` | v4.6.2 | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | node24 |
| `gacts/run-and-post-run` | v1.4.2 | [v1.4.4](https://github.com/gacts/run-and-post-run/releases/tag/v1.4.4) | node24 |

`actions/upload-artifact@v7` is backwards-compatible for the `name` + `path` usage here — the new `archive: false` direct-upload option is opt-in. v6 was the first node24 release; v7 additionally switched the action internals to ESM.

## Still stale (no node24 release upstream)

Three transitive deps remain on node20 because upstream hasn't cut a node24 release:

| Action | Latest | Last release | Viable alternative |
|---|---|---|---|
| `tale/kubectl-action` | v1.4.0 | 2024-02 | **Inline** — kubectl is pre-installed on `ubuntu-latest`, so this action is just `echo "$KUBECONFIG_B64" \| base64 -d > $HOME/.kube/config`. Or swap for [`azure/setup-kubectl@v5`](https://github.com/Azure/setup-kubectl) (node24, actively maintained) + the same inline decode. |
| `JarvusInnovations/background-action` | v1.0.7 | 2024-04 | **Inline** — used twice, both with a simple wait-on condition. Replace with `nohup <cmd> > /tmp/cmd.log 2>&1 &` + `timeout 60 bash -c 'until nc -z localhost 9710; do sleep 1; done'` (or `until [ -f <file> ]` for the log collector variant). |
| `DamianReeves/write-file-action` | v1.3 | 2024-02 | **Inline** — the action only writes a heredoc. Replace with `run: cat > path <<'EOF' ... EOF`. Trivial. |

All three have clean inline replacements — we don't need to wait on upstream. Happy to do those swaps in a follow-up PR if we want to fully drop node20 from this action.

## Test plan
- [ ] CI passes on this branch
- [ ] Verify `enclave-dump-*` artifacts are produced correctly on a real run (upload-artifact v4 -> v7 bump)
- [ ] Verify the `post:` hook still removes the kurtosis enclave on teardown (run-and-post-run bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)